### PR TITLE
Simplify MediaSession somewhat to not require audio playback

### DIFF
--- a/MediaSession.md
+++ b/MediaSession.md
@@ -9,11 +9,11 @@ When a media session becomes active, all other media sessions are either deactiv
 ## The `MediaSession` Interface
 
 ```WebIDL
-enum MediaSessionKind { "ambient", "main", "voice" };
+enum MediaSessionKind { "ambient", "default", "voice" };
 
 enum MediaSessionState { "inactive", "active", "suspended" };
 
-[Constructor()]
+[Constructor(optional MediaSessionKind kind = "default")]
 interface MediaSession : EventTarget {
     readonly attribute MediaSessionKind kind;
     readonly attribute MediaSessionState state;


### PR DESCRIPTION
This is motivated by @jernoble's explanation of the iOS model, as it
does not seem like media playback is required, only an active media
session. This hasn't been verfied, however:
https://github.com/whatwg/media-keys/issues/9#issuecomment-75272483